### PR TITLE
[FEAT]: Add private token contract

### DIFF
--- a/contracts/private_token/Nargo.toml
+++ b/contracts/private_token/Nargo.toml
@@ -4,6 +4,6 @@ type = "contract"
 authors = [""]
 
 [dependencies]
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.81.0", directory="noir-projects/aztec-nr/aztec" }
-value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.81.0", directory="noir-projects/aztec-nr/value-note"}
-easy_private_state = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.81.0", directory="noir-projects/aztec-nr/easy-private-state"}
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="aztec-packages-v0.76.4", directory="noir-projects/aztec-nr/aztec" }
+value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="aztec-packages-v0.76.4", directory="noir-projects/aztec-nr/value-note"}
+easy_private_state = { git="https://github.com/AztecProtocol/aztec-packages/", tag="aztec-packages-v0.76.4", directory="noir-projects/aztec-nr/easy-private-state"}

--- a/contracts/private_token/Nargo.toml
+++ b/contracts/private_token/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "private_token"
+type = "contract"
+authors = [""]
+
+[dependencies]
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.81.0", directory="noir-projects/aztec-nr/aztec" }
+value_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.81.0", directory="noir-projects/aztec-nr/value-note"}
+easy_private_state = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.81.0", directory="noir-projects/aztec-nr/easy-private-state"}

--- a/contracts/private_token/src/main.nr
+++ b/contracts/private_token/src/main.nr
@@ -1,0 +1,50 @@
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract PrivateToken {
+    use dep::aztec::macros::{functions::{initializer, private}, storage::storage};
+    use dep::aztec::prelude::{AztecAddress, Map};
+    use dep::easy_private_state::EasyPrivateUint;
+    use dep::value_note::balance_utils;
+
+    #[storage]
+    struct Storage<Context> {
+        balances: Map<AztecAddress, EasyPrivateUint<Context>, Context>,
+    }
+
+    /**
+     * initialize the contract's initial state variables.
+     */
+    #[private]
+    #[initializer]
+    fn constructor(initial_supply: u64, owner: AztecAddress) {
+        let balances = storage.balances;
+
+        balances.at(owner).add(initial_supply, owner, context.msg_sender());
+    }
+
+    // Mints `amount` of tokens to `owner`.
+    #[private]
+    fn mint(amount: u64, owner: AztecAddress) {
+        let balances = storage.balances;
+
+        balances.at(owner).add(amount, owner, context.msg_sender());
+    }
+
+    // Transfers `amount` of tokens from `sender` to a `recipient`.
+    #[private]
+    fn transfer(amount: u64, sender: AztecAddress, recipient: AztecAddress) {
+        let balances = storage.balances;
+
+        balances.at(sender).sub(amount, sender, sender);
+        balances.at(recipient).add(amount, recipient, sender);
+    }
+
+    // Helper function to get the balance of a user ("unconstrained" is a Noir alternative of Solidity's "view" function).
+    unconstrained fn get_balance(owner: AztecAddress) -> pub Field {
+        let balances = storage.balances;
+
+        // Return the sum of all notes in the set.
+        balance_utils::get_balance(balances.at(owner).set)
+    }
+}

--- a/contracts/private_token/src/main.nr
+++ b/contracts/private_token/src/main.nr
@@ -1,4 +1,5 @@
 use dep::aztec::macros::aztec;
+mod test;
 
 #[aztec]
 pub contract PrivateToken {

--- a/contracts/private_token/src/test.nr
+++ b/contracts/private_token/src/test.nr
@@ -1,0 +1,1 @@
+mod private_token;

--- a/contracts/private_token/src/test/private_token.nr
+++ b/contracts/private_token/src/test/private_token.nr
@@ -1,0 +1,21 @@
+use dep::aztec::{
+    context::PrivateContext,
+    prelude::AztecAddress,
+};
+
+use crate::PrivateToken;
+
+#[test]
+pub unconstrained fn test_simple_constructor() {
+    let deployer = AztecAddress::from(1);
+    let owner = AztecAddress::from(2);
+    let contract_address = AztecAddress::from(3);
+    
+    let mut context = PrivateContext::new(deployer, contract_address);
+    
+    let initial_supply = 1000;
+    PrivateToken::constructor(&mut context, initial_supply, owner);
+    
+    let balance = PrivateToken::get_balance(owner);
+    assert(balance == 1000, "Balance should be 1000");
+}


### PR DESCRIPTION
## Description

This PR implements a simple private token contract using Noir for the Aztec ecosystem. The token contract supports basic operations like minting and transferring tokens with privacy features.

Closes #22 

## Checklist

- [ ] Added tests
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking changes
- [ ] Other (please describe)

## Additional Notes

It's still in progress, just need to fix test
